### PR TITLE
Fix NoneType error when match_base is None in get_score() and get_utc_datetime()

### DIFF
--- a/match.py
+++ b/match.py
@@ -156,6 +156,8 @@ class Match:
         """
         Get the scheduled date and time of the match (UTC).
         """
+        if not self.data.match_base:
+            return None
         return self.data.match_base.match_information.planned_kickoff_time
     
     def get_local_datetime(self) -> datetime | None:
@@ -363,6 +365,8 @@ class Match:
         """
         Get a score string, including penalties if applicable.
         """
+        if self.data.match_base is None:
+            return "0-0"
         home_goals = self.data.match_base.match_information.home_team_goals
         away_goals = self.data.match_base.match_information.away_team_goals
         result = f"{home_goals}-{away_goals}"


### PR DESCRIPTION
Guard against match_base being None before accessing match_information,
which occurs when the match thread is created before kickoff.

https://claude.ai/code/session_01Py9J7aQrF2ZVBH5KKc8iZj